### PR TITLE
Feat/add path valid characters check

### DIFF
--- a/openapi-checks/src/main/java/org/sonar/openapi/checks/CheckList.java
+++ b/openapi-checks/src/main/java/org/sonar/openapi/checks/CheckList.java
@@ -44,7 +44,8 @@ public final class CheckList {
       ContactValidEmailCheck.class,
       DescriptionDiffersSummaryCheck.class,
       InvalidOperationIdName.class,
-      ProvideRequestBodyDescriptionCheck.class
+      ProvideRequestBodyDescriptionCheck.class,
+      PathValidCharactersCheck.class
     );
   }
 }

--- a/openapi-checks/src/main/java/org/sonar/openapi/checks/PathValidCharactersCheck.java
+++ b/openapi-checks/src/main/java/org/sonar/openapi/checks/PathValidCharactersCheck.java
@@ -1,0 +1,77 @@
+/*
+ * SonarQube OpenAPI Plugin
+ * Copyright (C) 2018-2019 Societe Generale
+ * vincent.girard-reydet AT socgen DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.openapi.checks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.sonar.sslr.api.AstNodeType;
+import java.util.Set;
+import java.util.Collection;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.openapi.api.OpenApiCheck;
+import org.sonar.plugins.openapi.api.v2.OpenApi2Grammar;
+import org.sonar.plugins.openapi.api.v3.OpenApi3Grammar;
+import org.sonar.sslr.yaml.grammar.JsonNode;
+import static org.sonar.openapi.checks.PathMaskeradingCheck.split;
+
+@Rule(key = PathValidCharactersCheck.CHECK_KEY)
+public class PathValidCharactersCheck extends OpenApiCheck {
+  public static final String CHECK_KEY = "PathValidCharacters";
+
+  @Override
+  public Set<AstNodeType> subscribedKinds() {
+    return Sets.newHashSet(OpenApi2Grammar.PATHS, OpenApi3Grammar.PATHS);
+  }
+
+  @Override
+  protected void visitNode(JsonNode node) {
+    Collection<JsonNode> paths = node.propertyMap().values();
+    checkPathCharacters(paths);
+  }
+
+  private void checkPathCharacters(Collection<JsonNode> paths){
+    for (JsonNode p : paths) {
+        String path = p.key().getTokenValue();
+        if (!isValidPath(path)){
+            addIssue("Path should not contain special characters.", p.key());
+        }
+    }
+  }
+
+  @VisibleForTesting
+  static boolean isValidPath(String path){
+    String[] splitPath = split(path);
+
+    for (String pathElement : splitPath){
+        String elementChars = pathElement;
+        if (pathElement.startsWith("{", 0) && pathElement.endsWith("}")){
+          elementChars = pathElement.substring(1, pathElement.length()-1);
+        }
+        for (Character ch : elementChars.toCharArray()){
+          if(!Character.isLetterOrDigit(ch)){
+              return false;
+          }
+        }
+    }
+    return true;
+  }
+
+}

--- a/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathValidCharacters.html
+++ b/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathValidCharacters.html
@@ -1,0 +1,20 @@
+<p>Paths defined in the OpenAPI specification should not use special characters since they get transformed into bad function names, depending on
+    the code generating tool which is used.
+</p>
+    
+    <h2>Noncompliant Code Example</h2>
+    <p>
+       Avoid using special characters in naming individual path elements, such as the ones used in snake case.
+    </p>
+    <pre>
+    /contracts/{contract_number}/quotas
+    /administration/token/dsaas-gateway/generate
+    </pre>
+    
+    <h2>Compliant Solution</h2>
+    
+    <p>Use camelCase when naming path elements</p>
+    <pre>
+    /contracts/{contractNumber}/quotas
+    /administration/token/dsaasGateway/generate
+    </pre>

--- a/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathValidCharacters.json
+++ b/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathValidCharacters.json
@@ -1,0 +1,15 @@
+{
+    "title": "Path should not contain special characters.",
+    "type": "BUG",
+    "status": "ready",
+    "remediation": {
+      "func": "Constant\/Issue",
+      "constantCost": "2mn"
+    },
+    "tags": [
+      "must"
+    ],
+    "defaultSeverity": "Blocker",
+    "sqKey": "PathValidCharacters"
+  }
+  

--- a/openapi-checks/src/test/java/org/sonar/openapi/checks/PathValidCharactersCheckTest.java
+++ b/openapi-checks/src/test/java/org/sonar/openapi/checks/PathValidCharactersCheckTest.java
@@ -1,0 +1,55 @@
+/*
+ * SonarQube OpenAPI Plugin
+ * Copyright (C) 2018-2019 Societe Generale
+ * vincent.girard-reydet AT socgen DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.openapi.checks;
+
+import org.junit.Test;
+import org.sonar.openapi.OpenApiCheckVerifier;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import static org.sonar.openapi.checks.PathValidCharactersCheck.isValidPath;
+
+public class PathValidCharactersCheckTest {
+
+
+  @Test
+  public void verify_path_string() {
+    assertTrue(isValidPath("/valid/path"));
+    assertTrue(isValidPath("/valid/path/with/{parameter}"));
+    assertTrue(isValidPath("/valid/path/number2/with/{parameter}"));
+
+    assertFalse(isValidPath("/invalid_path"));
+    assertFalse(isValidPath("/invalid_path/with/{parameter}"));
+    assertFalse(isValidPath("/valid/path/{with_invalid_parameter}/format"));
+    assertFalse(isValidPath("/random/inv@lid/path"));
+  }
+
+  @Test
+  public void verify_path_valid_characters_v2() {
+    OpenApiCheckVerifier.verify("src/test/resources/checks/v2/path-valid-characters.yaml", new PathValidCharactersCheck(), true);
+  }
+
+    @Test
+  public void verify_path_valid_characters_v3() {
+    OpenApiCheckVerifier.verify("src/test/resources/checks/v3/path-valid-characters.yaml", new PathValidCharactersCheck(), false);
+  }
+
+}

--- a/openapi-checks/src/test/resources/checks/v2/path-valid-characters.yaml
+++ b/openapi-checks/src/test/resources/checks/v2/path-valid-characters.yaml
@@ -1,0 +1,9 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /valid/path: {}
+  /valid/path/with/{parameter}: {}
+  /invalid_path: {} # Noncompliant: Path should not contain special characters.
+  /invalid/path_with/{parameter}: {} # Noncompliant: Path should not contain special characters.

--- a/openapi-checks/src/test/resources/checks/v3/path-valid-characters.yaml
+++ b/openapi-checks/src/test/resources/checks/v3/path-valid-characters.yaml
@@ -1,0 +1,9 @@
+swagger: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /valid/path: {}
+  /valid/path/with/{parameter}: {}
+  /invalid_path: {} # Noncompliant: Path should not contain special characters.
+  /invalid/path_with/{parameter}: {} # Noncompliant: Path should not contain special characters.


### PR DESCRIPTION
This check verifies that paths defined in the openapi specs do not contain special characters: - _ ? ,etc