### PR TITLE
Feat/path query parameters check

### DIFF
--- a/openapi-checks/src/main/java/org/sonar/openapi/checks/PathQueryParametersCheck.java
+++ b/openapi-checks/src/main/java/org/sonar/openapi/checks/PathQueryParametersCheck.java
@@ -1,0 +1,68 @@
+/*
+ * SonarQube OpenAPI Plugin
+ * Copyright (C) 2018-2019 Societe Generale
+ * vincent.girard-reydet AT socgen DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.openapi.checks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.sonar.sslr.api.AstNodeType;
+import java.util.Set;
+import java.util.Collection;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.openapi.api.OpenApiCheck;
+import org.sonar.plugins.openapi.api.v2.OpenApi2Grammar;
+import org.sonar.plugins.openapi.api.v3.OpenApi3Grammar;
+import org.sonar.sslr.yaml.grammar.JsonNode;
+import static org.sonar.openapi.checks.PathMaskeradingCheck.split;
+
+@Rule(key = PathQueryParametersCheck.CHECK_KEY)
+public class PathQueryParametersCheck extends OpenApiCheck {
+  public static final String CHECK_KEY = "PathQueryParameters";
+
+  @Override
+  public Set<AstNodeType> subscribedKinds() {
+    return Sets.newHashSet(OpenApi2Grammar.PATHS, OpenApi3Grammar.PATHS);
+  }
+
+  @Override
+  protected void visitNode(JsonNode node) {
+    Collection<JsonNode> paths = node.propertyMap().values();
+    checkPathCharacters(paths);
+  }
+
+  private void checkPathCharacters(Collection<JsonNode> paths){
+    for (JsonNode p : paths) {
+        String path = p.key().getTokenValue();
+        if (hasQueryParams(path)){
+            addIssue("Path should not include query parameters.", p.key());
+        }
+    }
+  }
+
+  @VisibleForTesting
+  static boolean hasQueryParams(String path){
+    String[] splitPath = split(path);
+    if (splitPath[splitPath.length - 1].contains("?")){
+        return true;
+    }
+    return false;
+  }
+
+}

--- a/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathQueryParameters.html
+++ b/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathQueryParameters.html
@@ -1,0 +1,24 @@
+<p>Query parameters should not be included in the paths of the OpenAPI specification. They have to be declared explicitly in the path object's definition.
+</p>
+    
+    <h2>Noncompliant Query String Path Example</h2>
+    <pre>
+    /path/with/query/?firstParameter&secondParameter
+    </pre>
+    
+    <h2>Compliant Solution</h2>
+    <p>Any query parameter description should be removed from the path itself and defined in the 'parameters' block of the endpoint.</p>
+    <pre>
+    /path/with/query/parameters:
+        parameters:
+            - in: query
+              name: firstParameter
+              schema:
+                type: integer
+              description: First parameter of the query parameters list
+            - in: query
+              name: secondParameter
+              schema:
+                type: integer
+              description: Second parameter of the query parameters list
+    </pre>

--- a/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathQueryParameters.json
+++ b/openapi-checks/src/main/resources/org.sonar/l10n/openapi/rules/openapi/PathQueryParameters.json
@@ -1,0 +1,14 @@
+{
+    "title": "Path should not include query parameters.",
+    "type": "BUG",
+    "status": "ready",
+    "remediation": {
+      "func": "Constant\/Issue",
+      "constantCost": "2mn"
+    },
+    "tags": [
+      "must"
+    ],
+    "defaultSeverity": "Blocker",
+    "sqKey": "PathQueryParameters"
+}

--- a/openapi-checks/src/test/java/org/sonar/openapi/checks/PathQueryParametersCheckTest.java
+++ b/openapi-checks/src/test/java/org/sonar/openapi/checks/PathQueryParametersCheckTest.java
@@ -19,33 +19,33 @@
  */
 package org.sonar.openapi.checks;
 
-import java.util.Arrays;
-import java.util.List;
+import org.junit.Test;
+import org.sonar.openapi.OpenApiCheckVerifier;
 
-public final class CheckList {
-  public static final String REPOSITORY_KEY = "openapi";
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
-  private CheckList() {
+import static org.sonar.openapi.checks.PathQueryParametersCheck.hasQueryParams;
+
+public class PathQueryParametersCheckTest {
+
+
+  @Test
+  public void verify_path_string() {
+    assertTrue(hasQueryParams("/path/with/query?param"));
+    assertTrue(hasQueryParams("/query?param"));
+
+    assertFalse(hasQueryParams("/invalid/character?/path"));
   }
 
-  public static List<Class> getChecks() {
-    return Arrays.asList(
-      PathMaskeradingCheck.class,
-      MediaTypeCheck.class,
-      ParsingErrorCheck.class,
-      DefaultResponseCheck.class,
-      DefinedResponseCheck.class,
-      DeclaredTagCheck.class,
-      DocumentedTagCheck.class,
-      AtMostOneBodyParameterCheck.class,
-      NoUnusedDefinitionCheck.class,
-      NoContentIn204Check.class,
-      ProvideOpSummaryCheck.class,
-      ContactValidEmailCheck.class,
-      DescriptionDiffersSummaryCheck.class,
-      InvalidOperationIdName.class,
-      ProvideRequestBodyDescriptionCheck.class,
-      PathQueryParametersCheck.class
-    );
+  @Test
+  public void verify_path_valid_characters_v2() {
+    OpenApiCheckVerifier.verify("src/test/resources/checks/v2/path-query-parameters.yaml", new PathQueryParametersCheck(), true);
   }
+
+    @Test
+  public void verify_path_valid_characters_v3() {
+    OpenApiCheckVerifier.verify("src/test/resources/checks/v3/path-query-parameters.yaml", new PathQueryParametersCheck(), false);
+  }
+
 }

--- a/openapi-checks/src/test/resources/checks/v2/path-query-parameters.yaml
+++ b/openapi-checks/src/test/resources/checks/v2/path-query-parameters.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /path/with/query/parameters:
+    parameters:
+        - in: query
+          name: firstParameter
+          schema:
+            type: integer
+          description: First parameter of the query parameters list
+        - in: query
+          name: secondParameter
+          schema:
+            type: integer
+          description: Second parameter of the query parameters list
+  /path/with/query/?firstParameter&secondParameter: {} # Noncompliant: Path should not include query parameters.

--- a/openapi-checks/src/test/resources/checks/v3/path-query-parameters.yaml
+++ b/openapi-checks/src/test/resources/checks/v3/path-query-parameters.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /path/with/query/parameters:
+    parameters:
+        - in: query
+          name: firstParameter
+          schema:
+            type: integer
+          description: First parameter of the query parameters list
+        - in: query
+          name: secondParameter
+          schema:
+            type: integer
+          description: Second parameter of the query parameters list
+  /path/with/query/?firstParameter&secondParameter: {} # Noncompliant: Path should not include query parameters.


### PR DESCRIPTION
This check verifies that query parameters are not included in the paths defined in the OpenAPI specs.
